### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,103 @@
-# cnpj-mysql
-Script em python para carregar os arquivos de cnpj dos dados públicos da Receita Federal em MYSQL e POSTGRESQL. O código é compatível com o layout das tabelas disponibilizadas pela Receita Federal a partir de 2021.
+cnpj-mysql
+Script em Python para carregar os arquivos de CNPJ dos dados públicos da Receita Federal em MySQL e PostgreSQL.
+📋 Descrição
+Este projeto fornece scripts automatizados para download e importação dos dados públicos de CNPJ da Receita Federal do Brasil em bancos de dados MySQL e PostgreSQL. O código é compatível com o layout das tabelas disponibilizadas pela Receita Federal a partir de 2021.
+🔗 Fonte dos Dados
+Os arquivos CSV zipados com os dados de CNPJs estão disponíveis em:
 
-## Dados públicos de cnpj no site da Receita:
-Os arquivos csv zipados com os dados de CNPJs estão disponíveis em https://dados.gov.br/dados/conjuntos-dados/cadastro-nacional-da-pessoa-juridica---cnpj ou https://arquivos.receitafederal.gov.br/dados/cnpj/dados_abertos_cnpj/ (a partir de 28/10/2024.)<br>
+https://dados.gov.br/dados/conjuntos-dados/cadastro-nacional-da-pessoa-juridica---cnpj
+https://arquivos.receitafederal.gov.br/dados/cnpj/dados_abertos_cnpj/ (disponível a partir de 28/10/2024)
+
+🛠️ Pré-requisitos
+Software
+
+Python 3.8 ou superior
+
+Bibliotecas Python
+bash# Bibliotecas principais
+pip install pandas dask sqlalchemy
+
+# Para MySQL
+pip install pymysql
+
+# Para PostgreSQL
+pip install psycopg2-binary
+
+Nota: O psycopg2-binary é recomendado para instalação mais simples. Testado no Ubuntu.
+
+📥 Download dos Dados
+Para baixar os arquivos da Receita Federal, execute:
+bashpython dados_cnpj_baixa.py
+Este comando irá:
+
+Buscar a relação de arquivos disponíveis no site da Receita Federal
+Baixar os arquivos zipados para a pasta dados-publicos-zip
 
 
-## Pré-requisitos:
-Python 3.8;<br>
-Bibliotecas pandas, dask, sqlalchemy. Para mysql instalar a biblioteca pymysql. Para postgres usar psycopg2.<br>
-Para instalar a biblioteca, use o comando<br>
-pip install pymysql<br>
-Para postgres, instale psycopg2 (recomenda-se psycopg2-binary para instalação mais simples)<br>
-pip install psycopg2-binary (testado no Ubuntu).<br>
+⚠️ Importante: Em 14/08/2024 a página de dados abertos foi modificada. O script dados_cnpj_baixa.py foi atualizado para buscar automaticamente a pasta do mês mais recente.
 
-## Utilizando o script:
-Para obter relação dos arquivos disponíveis no site da Receita Federal ou baixar os arquivos, faça o seguinte comando no Anaconda prompt:<br>
-<b>python dados_cnpj_baixa.py</b><br>
-Isto irá baixar os arquivos zipados do site da Receita na pasta "dados-publicos-zip".<br><br>
 
-<b>ATENÇÃO: Em 14/8/2024 a página de dados abertos foi modificada, o script dados_cnpj_baixa.py foi atualizado para pegar a pasta do mês mais recente.</b><br>
+💡 Dica: Se o download estiver muito lento, considere utilizar um gerenciador de downloads.
 
-Se o download estiverm muito lento, sugiro utilizar um gerenciador de downloads.<br>
+⚙️ Configuração
+1. Preparar Diretórios
+Crie uma pasta vazia chamada dados-publicos:
+bashmkdir dados-publicos
+2. Configurar Banco de Dados
+Crie um database no MySQL ou PostgreSQL:
+sqlCREATE DATABASE cnpj;
+3. Configurar Parâmetros de Conexão
+Edite o início do script com suas credenciais:
+pythondbname = 'cnpj'
+username = 'root'
+password = ''
+host = '127.0.0.1'
+🚀 Execução
+Para MySQL
+bashpython dados_cnpj_mysql.py
+Para PostgreSQL
+bashpython dados_cnpj_postgres.py
+⏱️ Tempo de Execução
 
-Crie uma pasta com o nome "dados-publicos". Esta pasta deve estar vazia.<br>
+MySQL: Aproximadamente 5 horas em notebook i7 de 8ª geração com Windows 10
+PostgreSQL: Testado com amostra em Linux (Ubuntu 20.04)
 
-No servidor MYSQL ou POSTGRES, crie um database, por exemplo, cnpj.<br>
-Especifique os parâmetros no começo do script:<br>
-dbname = 'cnpj'<br>
-username = 'root'<br>
-password = ''<br>
-host = '127.0.0.1'<br>
+Alternativa para Melhor Performance
+Se a execução estiver demorando muito, considere:
 
-Para iniciar esse script, em um console digite<br>
-python dados_cnpj_mysql.py<br>
-ou<br>
-python dados_cnpj_postgres.py<br>
+Usar o projeto cnpj-sqlite para gerar arquivo SQLite
+Converter para PostgreSQL usando ferramentas como:
 
-A execução durou cerca de 5hs em um notebook i7 de 8a geração com Windows 10 no script para mysql.
-No caso do postgres, fiz teste só com uma amostra em Linux (Ubuntu 20.4).
-Se a execução deste script demorar muito, uma opção é usar o projeto em https://github.com/rictom/cnpj-sqlite para gerar o arquivo em sqlite e usar uma ferramenta como o pgloader ou o DBeaver para converter depois em postgres.
-Este colega usou o pgloader com um bom desempenho: https://github.com/rictom/cnpj-mysql/issues/5
+pgloader
+DBeaver
 
-## Outras referências:
 
-Para trabalhar com os dados de cnpj no formato SQLITE, use o meu projeto (https://github.com/rictom/cnpj-sqlite).<br>
-A criação do arquivo sqlite é muita mais rápida que o carregamento da base em Mysql ou Postgres.<br>
-O projeto (https://github.com/rictom/rede-cnpj) utiliza os dados públicos de CNPJ para visualização de relacionamentos entre empresas e sócios.<br>
 
-## Histórico de versões
-versão 0.2 (janeiro/2022)
-- aceita sqlalchemy>=2.0;
-  
-versão 0.2 (julho/2022)
-- alterações menores no sql, para funcionar também em postgres;
-- versão para postgres.
 
-versão 0.1 (novembro/2021)
-- primeira versão
+📖 Exemplo de uso: Veja este caso de sucesso usando pgloader com bom desempenho.
+
+🔗 Projetos Relacionados
+
+cnpj-sqlite: Trabalhe com os dados de CNPJ no formato SQLite. A criação do arquivo SQLite é muito mais rápida que o carregamento em MySQL ou PostgreSQL.
+rede-cnpj: Visualização de relacionamentos entre empresas e sócios utilizando os dados públicos de CNPJ.
+
+📝 Histórico de Versões
+Versão 0.3 (janeiro/2022)
+
+✨ Suporte para SQLAlchemy >= 2.0
+
+Versão 0.2 (julho/2022)
+
+🔧 Alterações menores no SQL para compatibilidade com PostgreSQL
+➕ Adicionada versão para PostgreSQL
+
+Versão 0.1 (novembro/2021)
+
+🎉 Primeira versão
+
+📄 Licença
+Este projeto utiliza dados públicos da Receita Federal do Brasil.
+🤝 Contribuições
+Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou pull requests.
+
+Desenvolvido por: rictom


### PR DESCRIPTION
cnpj-mysql
Script em Python para carregar os arquivos de CNPJ dos dados públicos da Receita Federal em MySQL e PostgreSQL.
📋 Descrição
Este projeto fornece scripts automatizados para download e importação dos dados públicos de CNPJ da Receita Federal do Brasil em bancos de dados MySQL e PostgreSQL. O código é compatível com o layout das tabelas disponibilizadas pela Receita Federal a partir de 2021.
🔗 Fonte dos Dados
Os arquivos CSV zipados com os dados de CNPJs estão disponíveis em:

https://dados.gov.br/dados/conjuntos-dados/cadastro-nacional-da-pessoa-juridica---cnpj
https://arquivos.receitafederal.gov.br/dados/cnpj/dados_abertos_cnpj/ (disponível a partir de 28/10/2024)

🛠️ Pré-requisitos
Software

Python 3.8 ou superior

Bibliotecas Python
bash# Bibliotecas principais
pip install pandas dask sqlalchemy

# Para MySQL
pip install pymysql

# Para PostgreSQL
pip install psycopg2-binary

Nota: O psycopg2-binary é recomendado para instalação mais simples. Testado no Ubuntu.

📥 Download dos Dados
Para baixar os arquivos da Receita Federal, execute:
bashpython dados_cnpj_baixa.py
Este comando irá:

Buscar a relação de arquivos disponíveis no site da Receita Federal
Baixar os arquivos zipados para a pasta dados-publicos-zip


⚠️ Importante: Em 14/08/2024 a página de dados abertos foi modificada. O script dados_cnpj_baixa.py foi atualizado para buscar automaticamente a pasta do mês mais recente.


💡 Dica: Se o download estiver muito lento, considere utilizar um gerenciador de downloads.

⚙️ Configuração
1. Preparar Diretórios
Crie uma pasta vazia chamada dados-publicos:
bashmkdir dados-publicos
2. Configurar Banco de Dados
Crie um database no MySQL ou PostgreSQL:
sqlCREATE DATABASE cnpj;
3. Configurar Parâmetros de Conexão
Edite o início do script com suas credenciais:
pythondbname = 'cnpj'
username = 'root'
password = ''
host = '127.0.0.1'
🚀 Execução
Para MySQL
bashpython dados_cnpj_mysql.py
Para PostgreSQL
bashpython dados_cnpj_postgres.py
⏱️ Tempo de Execução

MySQL: Aproximadamente 5 horas em notebook i7 de 8ª geração com Windows 10
PostgreSQL: Testado com amostra em Linux (Ubuntu 20.04)

Alternativa para Melhor Performance
Se a execução estiver demorando muito, considere:

Usar o projeto [cnpj-sqlite](https://github.com/rictom/cnpj-sqlite) para gerar arquivo SQLite
Converter para PostgreSQL usando ferramentas como:

[pgloader](https://github.com/dimitri/pgloader)
DBeaver




📖 Exemplo de uso: Veja [este caso de sucesso](https://github.com/rictom/cnpj-mysql/issues/5) usando pgloader com bom desempenho.

🔗 Projetos Relacionados

[cnpj-sqlite](https://github.com/rictom/cnpj-sqlite): Trabalhe com os dados de CNPJ no formato SQLite. A criação do arquivo SQLite é muito mais rápida que o carregamento em MySQL ou PostgreSQL.
[rede-cnpj](https://github.com/rictom/rede-cnpj): Visualização de relacionamentos entre empresas e sócios utilizando os dados públicos de CNPJ.

📝 Histórico de Versões
Versão 0.3 (janeiro/2022)

✨ Suporte para SQLAlchemy >= 2.0

Versão 0.2 (julho/2022)

🔧 Alterações menores no SQL para compatibilidade com PostgreSQL
➕ Adicionada versão para PostgreSQL

Versão 0.1 (novembro/2021)

🎉 Primeira versão

📄 Licença
Este projeto utiliza dados públicos da Receita Federal do Brasil.
🤝 Contribuições
Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou pull requests.

Desenvolvido por: [rictom](https://github.com/rictom)